### PR TITLE
(#71) Use the choria audit log

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,7 +14,7 @@ mcollective::server_config:
   rpcauthorization: 1
   rpcauthprovider: "action_policy"
   rpcaudit: 1
-  rpcauditprovider: "logfile"
+  rpcauditprovider: "choria"
   plugin.rpcaudit.logfile: "/var/log/puppetlabs/mcollective-audit.log"
   factsource: "yaml"
   plugin.yaml: "/etc/puppetlabs/mcollective/generated-facts.yaml"

--- a/files/mcollective/pluginpackager/templates/aiomodule/README.md.erb
+++ b/files/mcollective/pluginpackager/templates/aiomodule/README.md.erb
@@ -26,7 +26,7 @@ Available Actions:
 
 ## Usage
 
-You can include this module into your infrastructure as any other module, but as it's designed to work with the [ripienaar mcollective](http://forge.puppet.com/ripienaar/mcollective) module you can configure it via Hiera:
+You can include this module into your infrastructure as any other module, but as it's designed to work with the [choria mcollective](http://forge.puppet.com/choria/mcollective) module you can configure it via Hiera:
 
 ```yaml
 mcollective::plugin_classes:


### PR DESCRIPTION
This enables the JSON audit log, the logfile is kept the same in case
people have existing logrotation in place I did not want to break that,
debatable if this is the best decision but its fine for < 1.0.0 I think

Additionally a small template update in the module packager readmes

Close #71 