### PR TITLE
(#72) Handle absent MCollective libraries better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/02/11|72   |When mcollective is not available in the RUBYLIB correctly handle the LoadError                          |
 |2017/02/11|80   |Set the `project_page` in the generated modules when packaging a plugin                                  |
 |2017/02/11|71   |Enable the `choria` auditing plugin by default                                                           |
 |2017/02/11|     |Release 0.0.24 and move to `choria-io` project                                                           |

--- a/lib/facter/mcollective.rb
+++ b/lib/facter/mcollective.rb
@@ -32,7 +32,7 @@ Facter.add(:mcollective) do
       end
 
       result
-    rescue
+    rescue StandardError, LoadError
       {"error" => "%s: %s" % [$!.class, $!.to_s]}
     end
   end


### PR DESCRIPTION
This should not happen in the typical scenario but someone might get the
Gems in their paths then this might happen, instead of preventing facter
from working this will now fail gracefully

Close #72 