### PR TITLE
(#89) Provide locking for MCollective refresh facts

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -41,6 +41,7 @@ mcollective::server: true
 mcollective::client: false
 mcollective::purge: false
 mcollective::facts_refresh_interval: 10
+mcollective::facts_pidfile: "/var/run/puppetlabs/mcollective-facts_refresh.pid"
 mcollective::service_name: "mcollective"
 mcollective::service_ensure: "running"
 mcollective::service_enable: true

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -5,6 +5,7 @@ mcollective::plugin_mode: ~
 mcollective::libdir: "C:/ProgramData/PuppetLabs/mcollective/plugins"
 mcollective::configdir: "C:/ProgramData/PuppetLabs/mcollective/etc"
 mcollective::rubypath: 'C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\ruby.exe'
+mcollective::facts_pidfile: "C:/ProgramData/PuppetLabs/mcollective/var/mcollective-facts_refresh.pid"
 
 # after PUP-7061 this can use lookup("mcollective::libdir") here
 mcollective::common_config:

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -6,6 +6,7 @@ class mcollective::facts (
   Integer $refresh_interval = $mcollective::facts_refresh_interval,
   Optional[String] $owner = $mcollective::plugin_owner,
   Optional[String] $group = $mcollective::plugin_group,
+  Optional[String] $pidfile = $mcollective::facts_pidfile,
   Boolean $server = $mcollective::server
 ) {
   $scriptpath = "${libdir}/mcollective/refresh_facts.rb"
@@ -33,11 +34,15 @@ class mcollective::facts (
     }
   }
 
+  if $pidfile {
+    $factspid = "-p '${pidfile}'"
+  }
+
   if $facts["os"]["family"] == "windows" {
     scheduled_task{"mcollective_facts_yaml_refresh":
       ensure               => $cron_ensure,
       command              => $rubypath,
-      arguments            => "'${scriptpath}' -o '${factspath}'",
+      arguments            => "'${scriptpath}' -o '${factspath}' ${factspid}",
       trigger              => {
         "schedule"         => "daily",
         "start_time"       => "00:00",
@@ -47,7 +52,7 @@ class mcollective::facts (
   } else {
     cron{"mcollective_facts_yaml_refresh":
       ensure  => $cron_ensure,
-      command => "'${rubypath}' '${scriptpath}' -o '${factspath}'",
+      command => "'${rubypath}' '${scriptpath}' -o '${factspath}' ${factspid}",
       minute  => "*/${refresh_interval}"
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@
 # @param client_collectives A list of collectives the client has access to, defaults to the same as the node
 # @param main_collective The main collective to use, last in the list of `$collectives` by default
 # @param client_main_collective The main collective to use on the client, `$main_collective` by default
+# @param facts_pidfile PID file path for locking fact refresh to a single execution
 # @param plugin_owner The default user who will own plugin files
 # @param plugin_group The default group who will own plugin files
 # @param plugin_mode The default mode plugin files will have
@@ -41,6 +42,7 @@ class mcollective (
   Array[Mcollective::Collective] $client_collectives = $collectives,
   Optional[Mcollective::Collective] $main_collective = undef,
   Optional[Mcollective::Collective] $client_main_collective = undef,
+  Optional[String] $facts_pidfile,
   Optional[String] $plugin_owner,
   Optional[String] $plugin_group,
   Optional[String] $plugin_mode,

--- a/templates/refresh_facts.erb
+++ b/templates/refresh_facts.erb
@@ -11,9 +11,31 @@ opt.on("--out FILE", "-o", "Path to facts") do |v|
   @outfile = v
 end
 
+opt.on("--pid FILE", "-p", "Path to pidfile") do |v|
+  @pid = v
+end
+
 opt.parse!
 
 abort("Please specify a file to write to") unless @outfile
+
+if @pid
+  begin
+    lock = File.open(@pid, File::CREAT | File::EXCL | File::WRONLY)
+
+    at_exit do
+      begin
+        lock.close
+      ensure
+        File.delete(@pid)
+      end
+    end
+
+    lock.write($$)
+  rescue
+    abort("Failed to obtain lock for %s using '%s', the refresher may already be running: %s: %s" % [$0, @pid, $!.class, $!.to_s])
+  end
+end
 
 require "rubygems"
 


### PR DESCRIPTION
This should ensure that - at most - one MCollective fact refresh should be running at any given moment.

We discovered that we have a fact that - in rare cases - takes a long time to resolve, which led to fact refreshes stacking up until the affected machines ran completely out of memory.
That proved to be a Bad Thing.

Hopefully this should prevent such a thing from affecting anyone else using MCollective.