### PR TITLE
(#95) Require the policy file before adding ini settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/03/24|95   |Ensure the policy file exist before the ini settings are attempted                                       |
 |2017/03/21|92   |Add utility to create config files                                                                       |
 |2017/02/13|     |Release 0.0.25                                                                                           |
 |2017/02/13|89   |Prevent multiple instances of the fact refresher from running                                            |

--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -100,7 +100,8 @@ define mcollective::module_plugin (
           ensure  => $ensure,
           path    => "${configdir}/plugin.d/${config_name}.cfg",
           setting => $item,
-          value   => $value
+          value   => $value,
+          require => File["${configdir}/plugin.d/${config_name}.cfg"]
         }
 
         Package <| tag == "mcollective_plugin_${name}_packages" |> -> Ini_setting["${name}-${config_name}-${item}"]


### PR DESCRIPTION
Generally Puppet auto requires will ensure that file /parent/child is
magically made after /parent, but ini_setting does not have a auto
require on its file

So this helps things along by specifically stating it, not clear why
this even failed since Puppet 4 is top down, but this is safer