### PR TITLE
(#98) Support gem mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/04/27|98   |Support local gem mirrors via the `gem_source` property                                                  |
 |2017/03/28|     |Release 0.0.26                                                                                           |
 |2017/03/24|95   |Ensure the policy file exist before the ini settings are attempted                                       |
 |2017/03/21|92   |Add utility to create config files                                                                       |

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@
 # @param client Install client files on this node
 # @param server Install server files on this node
 # @param purge When true will remove unmanaged files from the $configdir/plugin.d, $configdir/policies and $libdir
+# @param gem_source where to find gems, useful for local gem mirrors
 class mcollective (
   Array[String] $plugintypes,
   Array[String] $plugin_classes,
@@ -54,7 +55,8 @@ class mcollective (
   Boolean $service_enable,
   Boolean $client,
   Boolean $server,
-  Boolean $purge
+  Boolean $purge,
+  Optional[String] $gem_source = undef
 ) {
   $factspath = "${configdir}/generated-facts.yaml"
 

--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -62,6 +62,7 @@ define mcollective::module_plugin (
         package{$gem:
           ensure   => $version,
           provider => "puppet_gem",
+          source   => $mcollective::gem_source,
           tag      => "mcollective_plugin_${name}_packages"
         }
       }


### PR DESCRIPTION
For gems puppet needs a `source` parameter passed to `package` pointing
at the local gem mirror or on-disk location, this add `gem_source` to
set that for all module plugins