### PR TITLE
(#102) Remove deprecation warning messages

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,9 +1,12 @@
 ---
-version: 4
-datadir: "data"
+version: 5
+
+defaults:
+  datadir: "data"
+  data_hash: yaml_data
+
 hierarchy:
   - name: "OS family"
-    backend: yaml
-    path: "os/%{facts.os.family}"
+    path: "os/%{facts.os.family}.yaml"
   - name: "common"
-    backend: "yaml"
+    path: "common.yaml"

--- a/metadata.json
+++ b/metadata.json
@@ -105,8 +105,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.5.0"
+      "version_requirement": ">= 4.9.0"
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }


### PR DESCRIPTION
This patch updates the syntax of hiera.yaml file to version 5, as
version 4 is deprecated.