### PR TITLE
(#103) Remove deprecation warning messages for generated modules

### DIFF
--- a/files/mcollective/pluginpackager/templates/aiomodule/hiera.yaml.erb
+++ b/files/mcollective/pluginpackager/templates/aiomodule/hiera.yaml.erb
@@ -1,8 +1,12 @@
 ---
-version: 4
-datadir: "data"
+version: 5
+
+defaults:
+  datadir: "data"
+  data_hash: yaml_data
+
 hierarchy:
   - name: "plugin"
-    backend: "yaml"
+    path: "plugin.yaml"
   - name: "defaults"
-    backend: "yaml"
+    path: "defaults.yaml"

--- a/files/mcollective/pluginpackager/templates/aiomodule/metadata.json.erb
+++ b/files/mcollective/pluginpackager/templates/aiomodule/metadata.json.erb
@@ -12,9 +12,8 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.5.0"
+      "version_requirement": ">= 4.9.0"
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }
 


### PR DESCRIPTION
This commit:
  - bumps required puppet version to 4.9 (required by other changes)
  - updates hiera.yaml syntax to version 5
  - removes deprecated data_provider option from metadata.json