### PR TITLE
(#110) darwin support - plugin_group: wheel

### DIFF
--- a/data/os/Darwin.yaml
+++ b/data/os/Darwin.yaml
@@ -1,0 +1,1 @@
+mcollective::plugin_group: wheel


### PR DESCRIPTION
All it takes to make this class run out of the box on MacOSX