### PR TITLE
(#46) add a purging ini hanlder

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,6 +6,9 @@ mcollective::common_config:
   securityprovider: "choria"
   identity: "%{trusted.certname}"
   connector: "nats"
+  main_collective: "mcollective"
+  collectives: "mcollective"
+  libdir: "/opt/puppetlabs/mcollective/plugins"
 
 mcollective::policy_default: "deny"
 
@@ -20,6 +23,13 @@ mcollective::server_config:
   plugin.yaml: "/etc/puppetlabs/mcollective/generated-facts.yaml"
   registerinterval: 10
   registration: "Choria"
+  logfile: "/var/log/puppetlabs/mcollective.log"
+  daemonize: 1
+
+mcollective::client_config:
+  logger_type: "console"
+  loglevel: "warn"
+  connection_timeout: "3"
 
 mcollective::rpcutil_policies:
   - action: "allow"

--- a/functions/hash2config.pp
+++ b/functions/hash2config.pp
@@ -1,0 +1,8 @@
+# Generates configuration files for mcollective. Keys are sorted alphabetically:
+# key = value
+function mcollective::hash2config(Hash $confighash) >> String {
+  $result = $confighash.keys.sort.map |$key| {
+    sprintf("%s = %s", $key, $confighash[$key])
+  }
+  ($result << []).join("\n")
+}

--- a/manifests/config_file.pp
+++ b/manifests/config_file.pp
@@ -1,8 +1,5 @@
 # Utility to create mcollective config files
 #
-# Can either manipulate an existing config file
-# via ini settings or manage a whole file
-#
 # @param settings hash of settings to add via ini_setting
 # @param owner File ownership - only used when content is set
 # @param group File group ownership - only used when content is set
@@ -17,20 +14,15 @@ define mcollective::config_file (
   Enum["present", "absent"] $ensure = "present"
 ) {
   if $content {
-    file{$name:
-      owner   => $owner,
-      group   => $group,
-      mode    => $mode,
-      content => $content,
-      ensure  => $ensure
-    }
+    $body = $content
   } else {
-    $settings.each |$item, $value| {
-      ini_setting{"${name}_${item}":
-        path    => $name,
-        setting => $item,
-        value   => $value
-      }
-    }
+    $body = mcollective::hash2config($settings)
+  }
+  file{$name:
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
+    content => $body,
+    ensure  => $ensure
   }
 }

--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -89,23 +89,12 @@ define mcollective::module_plugin (
     }
 
     unless $merged_conf.empty {
-      file{"${configdir}/plugin.d/${config_name}.cfg":
-        owner  => $owner,
-        group  => $group,
-        mode   => $mode,
-        ensure => $ensure
-      }
-
-      $merged_conf.each |$item, $value| {
-        ini_setting{"${name}-${config_name}-${item}":
-          ensure  => $ensure,
-          path    => "${configdir}/plugin.d/${config_name}.cfg",
-          setting => $item,
-          value   => $value,
-          require => File["${configdir}/plugin.d/${config_name}.cfg"]
-        }
-
-        Package <| tag == "mcollective_plugin_${name}_packages" |> -> Ini_setting["${name}-${config_name}-${item}"]
+      mcollective::config_file { "${configdir}/plugin.d/${config_name}.cfg":
+        ensure   => $ensure,
+        settings => $merged_conf,
+        owner    => $owner,
+        group    => $group,
+        mode     => $mode
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -8,8 +8,7 @@
   "project_page": "https://github.com/choria-io/puppet-mcollective",
   "issues_url": "https://github.com/choria-io/puppet-mcollective/issues",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.12.0 < 5.0.0" },
-    { "name": "puppetlabs/inifile", "version_requirement": ">= 1.5.0 < 2.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.12.0 < 5.0.0" }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
WIP: Adds hash2ini function. Example:

```
$hash = {'general' => {'main' => true, 'homedir' => '/home/dir'}, 'sec2' => {'key' => 12, 'value' => '', 'boolean' => false}}

file {'/test.ini':
   content => mcollective::hash2ini($hash, "This file is managed by ${name}", "\r\n")
}
```
* Should we support more data types for values? (Namely arrays, I to not think hashes do make sense)
* Should we rather place this function with sub module, since they might need it or is it ok to rely in on `mcollective` module to be present?
