### PR TITLE
(#113) Staggered execution of facts cronjob

### DIFF
--- a/lib/puppet/functions/mcollective/crontimes.rb
+++ b/lib/puppet/functions/mcollective/crontimes.rb
@@ -1,0 +1,15 @@
+Puppet::Functions.create_function(:'mcollective::crontimes') do
+  dispatch :crontimes do
+    required_param 'Integer', :offset
+    required_param 'Integer', :interval
+    required_param 'Integer', :period
+  end
+
+  def crontimes(offset, interval, period)
+    (period / interval).times.map do |i|
+      val = i * interval + offset
+
+      val if val < period && val < 60
+    end.compact
+  end
+end

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -41,12 +41,12 @@ class mcollective::facts (
   if $facts["os"]["family"] == "windows" {
     # on windows task scheduler prevent dupes already so no need to handle the PID here
     scheduled_task{"mcollective_facts_yaml_refresh":
-      ensure               => $cron_ensure,
-      command              => $rubypath,
-      arguments            => "'${scriptpath}' -o '${factspath}'",
-      trigger              => {
+      ensure    => $cron_ensure,
+      command   => $rubypath,
+      arguments => "'${scriptpath}' -o '${factspath}'",
+      trigger   => {
         "schedule"         => "daily",
-        "start_time"       => "00:00",
+        "start_time"       => "00:${sprintf("%02d", fqdn_rand($refresh_interval, 'facts cronjob'))}",
         "minutes_interval" => $refresh_interval
       }
     }
@@ -54,7 +54,7 @@ class mcollective::facts (
     cron{"mcollective_facts_yaml_refresh":
       ensure  => $cron_ensure,
       command => "'${rubypath}' '${scriptpath}' -o '${factspath}' ${factspid}",
-      minute  => "*/${refresh_interval}"
+      minute  => mcollective::crontimes(fqdn_rand($refresh_interval, 'facts cronjob'), $refresh_interval, 60)
     }
   }
 }


### PR DESCRIPTION
This commit:
- Start the facts cronjob with a random offset.

This avoids many systems executing the job on the same moment, which is
beneficial for virtualized environments.