### PR TITLE
(#115) give top level properties priority over some settings

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,9 +6,6 @@ mcollective::common_config:
   securityprovider: "choria"
   identity: "%{trusted.certname}"
   connector: "nats"
-  main_collective: "mcollective"
-  collectives: "mcollective"
-  libdir: "/opt/puppetlabs/mcollective/plugins"
 
 mcollective::policy_default: "deny"
 

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -7,10 +7,6 @@ mcollective::configdir: "C:/ProgramData/PuppetLabs/mcollective/etc"
 mcollective::rubypath: 'C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\ruby.exe'
 mcollective::facts_pidfile: ~
 
-# after PUP-7061 this can use lookup("mcollective::libdir") here
-mcollective::common_config:
-  libdir: "C:/ProgramData/PuppetLabs/mcollective/plugins"
-
 mcollective::server_config:
   classesfile: "C:/ProgramData/PuppetLabs/puppet/cache/state/classes.txt"
   logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective.log"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,13 +21,24 @@ class mcollective::config {
     "main_collective" => $main_collective
   }
 
+  # some config settings are set directly on the main class, they are
+  # things other classes need to function for example libdir is also
+  # used by the plugin installer.  Specifically these settings should
+  # never be overridden by settings from the hashes since any difference
+  # between server/client cfg and what ends up being used by the plugin
+  # installer will lead to plugins not being found.
+  $global_config = {
+    "libdir" => $mcollective::libdir
+  }
+
   # The order of these are important:
   #
   # - common config is effectively defaults, overridable by specific server/client settings
   # - sub collective setup is derived from the class parameters, but should be overridable by server/client ccofig
   # - client_config and server_config has highest priority and overrules everything
-  $server_config = $mcollective::common_config + $server_collectives + $mcollective::server_config
-  $client_config = $mcollective::common_config + $client_collectives + $mcollective::client_config
+  # - global config for things like libdir that are properties on the main class.  These should always take the main properties.
+  $server_config = $mcollective::common_config + $server_collectives + $mcollective::server_config + $global_config
+  $client_config = $mcollective::common_config + $client_collectives + $mcollective::client_config + $global_config
 
   mcollective::config_file{"${mcollective::configdir}/server.cfg":
     settings => $server_config,


### PR DESCRIPTION
There's this unfortunate mix of things - libdir, logdir etc set at the
class and a mashup of settings from hashes.

Hashes are fine to some extend but for things that must be shared across
modules - like libdir being used by every module plugin to install
themselves - we need this as a top level var.

Ideally other settings too would be elevated but there's the ever
present hell of client vs server config which is unavoidable due to how
mcollective configs are designed

Worse the client/server configs cannot be enumerated because every
plugin ever can have any amount of variables in there.

So this solves the basic problem for libdir by making using its top
level value to override the data hashes giving the top setting priority
in the hash merges

This will always be nasty as long as mco config is as it is :(