### PR TITLE
Amends (#110) - missing metadata for Darwin

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -99,6 +99,14 @@
         "6.1",
         "7.1"
       ]
+    },
+    {
+      "operatingsystem": "Darwin",
+      "operatingsystemrelease": [
+        "10.10",
+        "10.11",
+        "10.12"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
Just adds metadata for AIO - supported Darwin releases