### PR TITLE
(#123) Ensure a valid --vendor is supplied when building modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/08/18|123  |Ensure a valid `--vendor` is passed when building modules                                                |
 |2017/08/02|     |Release 0.0.28                                                                                           |
 |2017/06/22|111  |Purge unmanaged config items from the managed config files                                               |
 |2017/06/19|113  |Randomize the start time of the facts cron job                                                           |

--- a/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
+++ b/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
@@ -12,9 +12,10 @@ module MCollective
 
       def create_packages
         assert_new_enough_puppet
+        validate_environment
 
         begin
-          puts("Building AIO module %s" % module_name)
+          puts("Building Choria module %s" % module_name)
 
           @tmpdir = Dir.mktmpdir('mcollective_packager')
 
@@ -133,6 +134,11 @@ module MCollective
           STDERR.puts("Could not render template %s to %s" % [infile, outfile])
           raise
         end
+      end
+
+      def validate_environment
+        raise("Supplying a vendor is required, please use --vendor") if @plugin.vendor == "Puppet Labs"
+        raise("Vendor names may not have a space in them, please specify a valid vendor using --vendor") if @plugin.vendor.match(" ")
       end
 
       def assert_new_enough_puppet


### PR DESCRIPTION
The vendor defaults to "Puppet Labs" which is not valid or apppropriate
for the use case, so now the plugin will do some validation and fail
nicer