### PR TITLE
(#126) Fix weird plugins permissions

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -54,7 +54,7 @@ mcollective::service_ensure: "running"
 mcollective::service_enable: true
 mcollective::plugin_owner: "root"
 mcollective::plugin_group: "root"
-mcollective::plugin_mode: "0664"
+mcollective::plugin_mode: "0644"
 mcollective::libdir: "/opt/puppetlabs/mcollective/plugins"
 mcollective::configdir: "/etc/puppetlabs/mcollective"
 mcollective::rubypath: "/opt/puppetlabs/puppet/bin/ruby"


### PR DESCRIPTION
Instead of the traditional 755 / 644 permissions for directories and
files, the module used 775 / 664 permissions which looks inconsistent
with the rest of the system on UNIX like operating systems.