### PR TITLE
(#128) Use the wheel group root on FreeBSD

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,0 +1,2 @@
+---
+mcollective::plugin_group: wheel


### PR DESCRIPTION
FreeBSD does not have a `root` group.