### PR TITLE
(#134) Improve MCollective configuration finding

### DIFF
--- a/lib/facter/mcollective.rb
+++ b/lib/facter/mcollective.rb
@@ -13,7 +13,14 @@ Facter.add(:mcollective) do
         if MCollective::Util.windows?
           configfile = File.join(MCollective::Util.windows_prefix, "etc", "%s.cfg" % config)
         else
-          configfile = "/etc/puppetlabs/mcollective/%s.cfg" % config
+          [
+            "/etc/puppetlabs/mcollective/%s.cfg",
+            "/usr/local/etc/mcollective/%s.cfg",
+            "/etc/mcollective/%s.cfg",
+          ].each do |path|
+            configfile = path % config
+            break if File.exists?(configfile)
+          end
         end
 
         mconfig = MCollective::Config.instance


### PR DESCRIPTION
Add some extra path to look for the MCollective configuration on non-AIO
hosts.