### PR TITLE
(#138) Allow plugins to supply additional puppet files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/10/18|138  |Allow plugins to supply additional Puppet files to copy into modules                                     |
 |2017/09/21|     |Release 0.1.0                                                                                            |
 |2017/09/08|128-134|Support FreeBSD                                                                                        |
 |2017/09/08|126  |Improve unixlike behaviour in plugin permissions                                                         |

--- a/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
+++ b/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
@@ -22,6 +22,7 @@ module MCollective
           make_module_dirs
           copy_module_files
           render_templates
+          copy_additional_files
           run_build
           move_package
 
@@ -77,7 +78,7 @@ module MCollective
       end
 
       def module_override_data
-        YAML.load_file(".plugin.yaml")
+        YAML.safe_load(File.read(".plugin.yaml"))
       rescue
         {}
       end
@@ -97,6 +98,14 @@ module MCollective
       def make_module_dirs
         ["data", "manifests", "files/mcollective"].each do |dir|
           FileUtils.mkdir_p(File.join(@tmpdir, dir))
+        end
+      end
+
+      def copy_additional_files
+        if File.exist?("puppet")
+          Dir.glob("puppet/*").each do |file|
+            FileUtils.cp_r(file, @tmpdir)
+          end
         end
       end
 


### PR DESCRIPTION
If a agent repo has a `puppet` directory this directory will be
recursively copied into the final module after all automated renders of
templates and so forth is done

This allow users to stick additional files and so forth in, the
canonical use is to ship plans and functions and tasks related to the
plugins but I guess it can be (ab)used for many useful things