### PR TITLE
(#140) fix gathering mcollective fact during cache generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/10/18|140  |Fix gathering mcollective facts from the fact cache builder                                              |
 |2017/10/18|138  |Allow plugins to supply additional Puppet files to copy into modules                                     |
 |2017/09/21|     |Release 0.1.0                                                                                            |
 |2017/09/08|128-134|Support FreeBSD                                                                                        |

--- a/templates/refresh_facts.erb
+++ b/templates/refresh_facts.erb
@@ -41,6 +41,7 @@ require "rubygems"
 
 if Gem.win_platform?
   $: << "C:/Program Files/Puppet Labs/Puppet/facter/lib"
+  $: << "C:/Program Files/Puppet Labs/Puppet/mcollective/lib"
 end
 
 require "yaml"


### PR DESCRIPTION
On windows the lib dirs for the various projects are individual rather
than combined like on windows

This adds the mcollective lib dir to the LOAD_PATH ensuring the
mcollective fact can find the mcollective libraries

Close #140 