### PR TITLE
(#151) Remove dependency on choria/mcollective_choria to fix cyclic dependency issue

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,8 +8,7 @@
   "project_page": "https://github.com/choria-io/puppet-mcollective",
   "issues_url": "https://github.com/choria-io/puppet-mcollective/issues",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.12.0 < 5.0.0" },
-    { "name": "choria/mcollective_choria", "version_requirement": ">= 0.0.27 < 2.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.12.0 < 5.0.0" }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This fixes a cyclic dependency issue when using Librarian-Puppet to resolve dependencies.

Original issue: https://github.com/choria-io/mcollective-choria/issues/381

Removing the dependency on `choria/mcollective_choria` means we can use Librarian to recursively resolve dependencies when run against a Puppetfile containing:

```
mod 'choria/mcollective_choria', '0.5.0'
```
  