### PR TITLE
(#163) Workaround for YAML aliasing

### DIFF
--- a/lib/facter/mcollective.rb
+++ b/lib/facter/mcollective.rb
@@ -30,7 +30,7 @@ Facter.add(:mcollective) do
           mconfig.set_config_defaults(configfile)
           mconfig.loadconfig(configfile)
 
-          result[config]["libdir"] = mconfig.libdir
+          result[config]["libdir"] = mconfig.libdir.dup
           result[config]["connector"] = mconfig.connector.downcase
           result[config]["securityprovider"] = mconfig.securityprovider.downcase
           result[config]["collectives"] = mconfig.collectives


### PR DESCRIPTION
Not sure if this should be merged as it, but until a long-term fix is available, it might help people working with choria and missing their facts with Puppet 5.5…

---

With Puppet 5.5, the `refresh_facts.rb` produce a YAML file containing aliases, which are not properly processed (choria-io/mcollective-choria#455).

This workaround prevents the same object to be assigned to `mcollective::client::libdir` and `mcollective::server::libdir` by duplicating them.  The Psych serializer then consider them as two distinct objects and does not emit an alias.