### PR TITLE
(#174) unamange federation config directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -63,11 +63,4 @@ class mcollective::config {
     content => $policy_content,
     notify  => Class["mcollective::service"]
   }
-
-  file{"${mcollective::configdir}/federation":
-    owner  => $mcollective::plugin_owner,
-    group  => $mcollective::plugin_group,
-    mode   => $mcollective::plugin_mode,
-    ensure => "directory"
-  }
 }


### PR DESCRIPTION
Ruby federation is now dead, so we stop creating the directory but
leave existing ones in place so admins can decide for themselves if
they are done