### PR TITLE
(#178) move schemas to better urls

### DIFF
--- a/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
+++ b/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
@@ -135,7 +135,7 @@ module MCollective
             ddl.instance_eval(File.read(file))
 
             data = {
-              "$schema" => "https://choria.io/schemas/mcorpc/agent:1.json",
+              "$schema" => "https://choria.io/schemas/mcorpc/ddl/v1/agent.json",
               "metadata" => ddl.meta,
               "actions" => [],
             }


### PR DESCRIPTION
Previously the schemas were all over, now they are in one repo and
the file names are such that windows machine can clone this repo (sigh)