### PR TITLE
(#188) Add OpenBSD support

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -61,6 +61,7 @@ mcollective::plugin_mode: "0644"
 mcollective::libdir: "/opt/puppetlabs/mcollective/plugins"
 mcollective::configdir: "/etc/puppetlabs/mcollective"
 mcollective::rubypath: "/opt/puppetlabs/puppet/bin/ruby"
+mcollective::gem_provider: "puppet_gem"
 mcollective::plugintypes:
   - "agent"
   - "aggregate"

--- a/data/os/OpenBSD.yaml
+++ b/data/os/OpenBSD.yaml
@@ -1,0 +1,22 @@
+---
+mcollective::plugin_group: wheel
+mcollective::service_name: mcollectived
+mcollective::configdir: "/etc/mcollective"
+mcollective::libdir: "/usr/local/libexec/mcollective"
+mcollective::rubypath: "/usr/local/bin/ruby24"
+mcollective::gem_provider: "gem"
+mcollective::manage_package: true
+
+mcollective::server_config:
+  classesfile: "/var/puppetlabs/puppet/cache/state/classes.txt"
+  rpcauthorization: 1
+  rpcauthprovider: "action_policy"
+  rpcaudit: 1
+  rpcauditprovider: "choria"
+  plugin.rpcaudit.logfile: "/var/log/puppetlabs/mcollective-audit.log"
+  factsource: "yaml"
+  plugin.yaml: "/etc/mcollective/generated-facts.yaml"
+  registerinterval: 10
+  registration: "Choria"
+  logfile: "/var/log/puppetlabs/mcollective.log"
+  daemonize: 1

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,8 @@ class mcollective (
   Boolean $client,
   Boolean $server,
   Boolean $purge,
-  Optional[String] $gem_source = undef
+  Optional[String] $gem_source = undef,
+  String $gem_provider
 ) {
   $factspath = "${configdir}/generated-facts.yaml"
 

--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -61,7 +61,7 @@ define mcollective::module_plugin (
       $gem_dependencies.each |$gem, $version| {
         package{$gem:
           ensure   => $version,
-          provider => "puppet_gem",
+          provider => $mcollective::gem_provider,
           source   => $mcollective::gem_source,
           tag      => "mcollective_plugin_${name}_packages"
         }


### PR DESCRIPTION
Add OpenBSD support by adding hieradata and a variable to choose the gem provider (`puppet_gem` is not supported on OpenBSD)