### PR TITLE
(#200) create old mcollective dirs on AIO 6

### DIFF
--- a/manifests/plugin_dirs.pp
+++ b/manifests/plugin_dirs.pp
@@ -3,13 +3,22 @@ class mcollective::plugin_dirs {
     "${mcollective::libdir}/mcollective/${type}"
   }
 
+  if "aio_agent_version" in $facts and $facts["aio_agent_version"] =~ /^6/ {
+    $extra_dirs = [
+      "/etc/puppetlabs/mcollective",
+      "/opt/puppetlabs/mcollective",
+      "/opt/puppetlabs/mcollective/mcollective"
+    ]
+  } else {
+    $extra_dirs = []
+  }
+
   $needed_dirs = [
     "${mcollective::configdir}/plugin.d",
     "${mcollective::configdir}/policies",
     $mcollective::libdir,
     "${mcollective::libdir}/mcollective",
-    $libdirs
-  ]
+  ] + $libdirs + $extra_dirs
 
   if $mcollective::purge {
     $purge_options = {


### PR DESCRIPTION
When running on AIO 6 create the old mcollective directories