### PR TITLE
(#208) Redirect cron output to /dev/null

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -55,7 +55,7 @@ class mcollective::facts (
   } else {
     cron{"mcollective_facts_yaml_refresh":
       ensure  => $cron_ensure,
-      command => "'${rubypath}' '${scriptpath}' -o '${factspath}' ${factspid}",
+      command => "'${rubypath}' '${scriptpath}' -o '${factspath}' ${factspid} 2>&1 > /dev/null",
       minute  => $cron_minutes
     }
   }


### PR DESCRIPTION
We're getting bombarded with cron emails when the refresh_facts.rb generates warnings.  We'd like to suppress them.