### PR TITLE
(#206) disable mcollectived on aio 6

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -63,6 +63,7 @@ mcollective::libdir: "/opt/puppetlabs/mcollective/plugins"
 mcollective::configdir: "/etc/puppetlabs/mcollective"
 mcollective::rubypath: "/opt/puppetlabs/puppet/bin/ruby"
 mcollective::gem_provider: "puppet_gem"
+mcollective::manage_bin_symlinks: false
 mcollective::plugintypes:
   - "agent"
   - "aggregate"
@@ -76,6 +77,11 @@ mcollective::plugintypes:
   - "util"
   - "validator"
   - "pluginpackager"
+
+mcollective::required_directories:
+  - /etc/puppetlabs/mcollective
+  - /opt/puppetlabs/mcollective
+  - /opt/puppetlabs/mcollective/mcollective
 
 lookup_options:
   mcollective::collectives:

--- a/data/os/Archlinux.yaml
+++ b/data/os/Archlinux.yaml
@@ -3,3 +3,5 @@ mcollective::libdir: "/etc/puppetlabs/mcollective/plugins"
 mcollective::rubypath: "/usr/bin/ruby"
 mcollective::package_name: "mcollective"
 mcollective::manage_package: true
+mcollective::required_directories: []
+mcollective::manage_bin_symlinks: false

--- a/data/os/Darwin.yaml
+++ b/data/os/Darwin.yaml
@@ -1,1 +1,2 @@
 mcollective::plugin_group: wheel
+mcollective::required_directories: []

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -7,6 +7,8 @@ mcollective::libdir: "/usr/local/share"
 mcollective::rubypath: "/usr/local/bin/ruby"
 mcollective::gem_provider: "gem"
 mcollective::manage_package: true
+mcollective::required_directories: []
+mcollective::manage_bin_symlinks: false
 
 mcollective::server_config:
   classesfile: "/var/puppet/state/classes.txt"

--- a/data/os/OpenBSD.yaml
+++ b/data/os/OpenBSD.yaml
@@ -7,6 +7,8 @@ mcollective::libdir: "/usr/local/libexec/mcollective"
 mcollective::rubypath: "/usr/local/bin/ruby24"
 mcollective::gem_provider: "gem"
 mcollective::manage_package: true
+mcollective::required_directories: []
+mcollective::manage_bin_symlinks: false
 
 mcollective::server_config:
   classesfile: "/var/puppetlabs/puppet/cache/state/classes.txt"

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -7,6 +7,13 @@ mcollective::libdir: "C:/ProgramData/PuppetLabs/mcollective/plugins"
 mcollective::configdir: "C:/ProgramData/PuppetLabs/mcollective/etc"
 mcollective::rubypath: 'C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\ruby.exe'
 mcollective::facts_pidfile: ~
+mcollective::manage_bin_symlinks: false
+
+mcollective::required_directories:
+  - "C:/ProgramData/PuppetLabs/mcollective"
+  - "C:/ProgramData/PuppetLabs/mcollective/etc"
+  - "C:/ProgramData/PuppetLabs/mcollective/var"
+  - "C:/ProgramData/PuppetLabs/mcollective/var/log"
 
 mcollective::server_config:
   classesfile: "C:/ProgramData/PuppetLabs/puppet/cache/state/classes.txt"

--- a/data/puppet_aio/6.yaml
+++ b/data/puppet_aio/6.yaml
@@ -1,0 +1,3 @@
+mcollective::service_ensure: stopped
+mcollective::service_enable: false
+mcollective::manage_bin_symlinks: true

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -8,5 +8,9 @@ defaults:
 hierarchy:
   - name: "OS family"
     path: "os/%{facts.os.family}.yaml"
+
+  - name: "AIO version specific common"
+    path: "puppet_aio/%{facts.mcollective.aio_major_version}.yaml"
+
   - name: "common"
     path: "common.yaml"

--- a/lib/facter/mcollective.rb
+++ b/lib/facter/mcollective.rb
@@ -1,13 +1,20 @@
 Facter.add(:mcollective) do
+  pver = Facter.value(:puppetversion)
+  aiover = Facter.value(:aio_agent_version)
+
   setcode do
+    result = {
+      "client" => {},
+      "server" => {},
+      "puppet_major_version" => 0,
+      "aio_major_version" => 0
+    }
+
+    result["puppet_major_version"] = pver.split(".").first.to_i if pver
+    result["aio_major_version"] = aiover.split(".").first.to_i if aiover
+
     begin
       require "mcollective"
-
-      result = {
-        "version" => MCollective::VERSION,
-        "client" => {},
-        "server" => {}
-      }
 
       ["client", "server"].each do |config|
         if MCollective::Util.windows?
@@ -40,7 +47,9 @@ Facter.add(:mcollective) do
 
       result
     rescue StandardError, LoadError
-      {"error" => "%s: %s" % [$!.class, $!.to_s]}
+      result["error"] = "%s: %s" % [$!.class, $!.to_s]
     end
+
+    result
   end
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,13 +1,8 @@
 class mcollective::config {
-  if "aio_agent_version" in $facts and $facts["aio_agent_version"] =~ /^6/ {
-    # on windows we will need a bat file wrapper or something, anyway these
-    # hard coded paths would be different for now I'll just skip this till
-    # later
-    if $facts["os"]["family"] != "windows" {
-      file{"${mcollective::bindir}/mco":
-        ensure => link,
-        target => "/opt/puppetlabs/puppet/bin/mco",
-      }
+  if $mcollective::manage_bin_symlinks {
+    file{"${mcollective::bindir}/mco":
+      ensure => link,
+      target => "/opt/puppetlabs/puppet/bin/mco",
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@
 # @param plugin_owner The default user who will own plugin files
 # @param plugin_group The default group who will own plugin files
 # @param plugin_mode The default mode plugin files will have
+# @param required_directories Any extra directories that should be created before copying plugins and configuration
 # @param policy_default When managing plugin policies this will be the default allow/deny
 # @param site_policies Policies to apply to all agents after any module specific policies
 # @param rpcutil_policies Policies to apply to the special rpcutil agent
@@ -32,6 +33,7 @@
 # @param server Install server files on this node
 # @param purge When true will remove unmanaged files from the $configdir/plugin.d, $configdir/policies and $libdir
 # @param gem_source where to find gems, useful for local gem mirrors
+# @param manage_bin_symlinks Enables creating symlinks in the bin dir for the mco command
 class mcollective (
   Array[String] $plugintypes,
   Array[String] $plugin_classes,
@@ -43,6 +45,7 @@ class mcollective (
   String $libdir,
   String $configdir,
   String $rubypath,
+  Boolean $manage_bin_symlinks = false,
   Integer $facts_refresh_interval,
   Array[Mcollective::Collective] $collectives,
   Array[Mcollective::Collective] $client_collectives = $collectives,
@@ -52,6 +55,7 @@ class mcollective (
   Optional[String] $plugin_owner,
   Optional[String] $plugin_group,
   Optional[String] $plugin_mode,
+  Array[String] $required_directories = [],
   Mcollective::Policy_action $policy_default,
   Array[Mcollective::Policy] $site_policies = [],
   Array[Mcollective::Policy] $rpcutil_policies = [],

--- a/manifests/plugin_dirs.pp
+++ b/manifests/plugin_dirs.pp
@@ -3,22 +3,12 @@ class mcollective::plugin_dirs {
     "${mcollective::libdir}/mcollective/${type}"
   }
 
-  if "aio_agent_version" in $facts and $facts["aio_agent_version"] =~ /^6/ {
-    $extra_dirs = [
-      "/etc/puppetlabs/mcollective",
-      "/opt/puppetlabs/mcollective",
-      "/opt/puppetlabs/mcollective/mcollective"
-    ]
-  } else {
-    $extra_dirs = []
-  }
-
   $needed_dirs = [
     "${mcollective::configdir}/plugin.d",
     "${mcollective::configdir}/policies",
     $mcollective::libdir,
     "${mcollective::libdir}/mcollective",
-  ] + $libdirs + $extra_dirs
+  ] + $libdirs + $mcollective::required_directories
 
   if $mcollective::purge {
     $purge_options = {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,8 +1,4 @@
 class mcollective::service {
-  if "aio_agent_version" in $facts and $facts["aio_agent_version"] =~ /^6/ {
-    return()
-  }
-
   service{$mcollective::service_name:
     ensure => $mcollective::service_ensure,
     enable => $mcollective::service_enable


### PR DESCRIPTION
This adds a few bits to the mcollective fact that helps identify the
major version of AIO and Puppet and ensure its always created at least
in skeleton

It then uses this data to add a hiera tier for AIO Major version and
uses that tier to remove some of the bad conditionals that was added
earlier to branch on AIO 6

The settings for extra directories that AIO does not make has been moved
to OS specific hiera

AIO specific hiera disables mcollectived