### PR TITLE
(#200) do not purge puppet directories

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -57,6 +57,16 @@ class mcollective::config {
   $server_config = $mcollective::common_config + $server_collectives + $mcollective::server_config + $global_config
   $client_config = $mcollective::common_config + $client_collectives + $mcollective::client_config + $global_config
 
+
+  $mcollective::required_directories.each |$dir| {
+    file{$dir:
+      ensure => "directory",
+      owner  => $mcollective::plugin_owner,
+      group  => $mcollective::plugin_group,
+      mode   => "0755"
+    }
+  }
+
   mcollective::config_file{"${mcollective::configdir}/server.cfg":
     settings => $server_config,
     notify   => Class["mcollective::service"]

--- a/manifests/plugin_dirs.pp
+++ b/manifests/plugin_dirs.pp
@@ -8,7 +8,7 @@ class mcollective::plugin_dirs {
     "${mcollective::configdir}/policies",
     $mcollective::libdir,
     "${mcollective::libdir}/mcollective",
-  ] + $libdirs + $mcollective::required_directories
+  ] + $libdirs
 
   if $mcollective::purge {
     $purge_options = {


### PR DESCRIPTION
Handling the puppet directories as plugin dirs has the undesired effect
of purging them, this moves them to just plain directories