### PR TITLE
(#223) Change `refresh_facts.rb` mode to `0775`

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -14,7 +14,7 @@ class mcollective::facts (
   file{$scriptpath:
     owner   => $owner,
     group   => $group,
-    mode    => "0755",
+    mode    => "0775",
     content => template("mcollective/refresh_facts.erb"),
   }
 


### PR DESCRIPTION
On Windows, if the owner and the group are set the same, modes such as `0755` cause unnecessary repeated changes as it tries to change `0775` to `0755` on each run.

Setting the mode as `0775` should be safe as for most OSes the plugin group is `root` and therefore for most configurations does not expose write access to any new accounts. For BSD derivatives, the `wheel` group has the same considerations.

See #223.