### PR TITLE
Update metadata.json to allow Puppet 6.x (#227)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -111,7 +111,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.9.0 < 6.0.0"
+      "version_requirement": ">= 4.9.0 < 7.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -111,7 +111,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.9.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
This module supports Puppet 6 already, but the metadata does not document this. This is a tiny change to allow 6.x to work

Note: I have explicitly chosen not to mark support as simply `>= 4.9.0` as it's not clear to me that all future Puppet versions will automatically "just work". Having said that `choria/choria` has this so I'm not sure if @ripienaar has a different idea.