### PR TITLE
Allow specifying install_options for gem_dependencies

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@
 # @param server Install server files on this node
 # @param purge When true will remove unmanaged files from the $configdir/plugin.d, $configdir/policies and $libdir
 # @param gem_source where to find gems, useful for local gem mirrors
+# @param gem_install_options Options to customise gem installation
 # @param manage_bin_symlinks Enables creating symlinks in the bin dir for the mco command
 class mcollective (
   Array[String] $plugintypes,
@@ -69,6 +70,7 @@ class mcollective (
   Boolean $server,
   Boolean $purge,
   Optional[String] $gem_source = undef,
+  Optional[Array[Variant[String,Hash[String,String]]]] $gem_install_options = undef,
   String $gem_provider
 ) {
   $factspath = "${configdir}/generated-facts.yaml"

--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -67,10 +67,11 @@ define mcollective::module_plugin (
     if $manage_gem_dependencies {
       $gem_dependencies.each |$gem, $version| {
         package{$gem:
-          ensure   => $version,
-          provider => $mcollective::gem_provider,
-          source   => $mcollective::gem_source,
-          tag      => "mcollective_plugin_${name}_packages"
+          ensure          => $version,
+          provider        => $mcollective::gem_provider,
+          source          => $mcollective::gem_source,
+          install_options => $mcollective::gem_install_options,
+          tag             => "mcollective_plugin_${name}_packages"
         }
       }
     }


### PR DESCRIPTION
Use case:
On sites behind a corporate proxy, this is needed to be able
to specify the proxy address consistently. The gem command will
pick up the environment `http_proxy` and `no_proxy` environment
variables if set, but when running under sudo, cron or system service
these variables may not be available.