### PR TITLE
(misc) Fix ruby path on Windows with Puppet 6

### DIFF
--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -3,21 +3,22 @@ mcollective::plugin_group: ~
 mcollective::plugin_mode: ~
 mcollective::plugin_executable_mode: ~
 
-mcollective::bindir: "C:/Program Files/Puppet Labs/Puppet/bin"
-mcollective::libdir: "C:/ProgramData/PuppetLabs/mcollective/plugins"
-mcollective::configdir: "C:/ProgramData/PuppetLabs/mcollective/etc"
+mcollective::bindir: "C:/Program Files/choria/bin"
+mcollective::libdir: "C:/ProgramData/choria/lib/plugins"
+mcollective::configdir: "C:/ProgramData/choria/etc"
 mcollective::rubypath: "C:/Program Files/Puppet Labs/Puppet/puppet/bin/ruby.exe"
 mcollective::facts_pidfile: ~
 mcollective::manage_bin_symlinks: false
 
 mcollective::required_directories:
-  - "C:/ProgramData/PuppetLabs/mcollective"
-  - "C:/ProgramData/PuppetLabs/mcollective/etc"
-  - "C:/ProgramData/PuppetLabs/mcollective/var"
-  - "C:/ProgramData/PuppetLabs/mcollective/var/log"
+  - "C:/ProgramData/choria"
+  - "C:/ProgramData/choria/etc"
+  - "C:/ProgramData/choria/lib"
+  - "C:/ProgramData/choria/var"
+  - "C:/ProgramData/choria/var/log"
 
 mcollective::server_config:
   classesfile: "C:/ProgramData/PuppetLabs/puppet/cache/state/classes.txt"
-  logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective.log"
-  plugin.rpcaudit.logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log"
-  plugin.yaml: "C:/ProgramData/PuppetLabs/mcollective/etc/generated-facts.yaml"
+  logfile: "C:/ProgramData/choria/var/log/mcollective.log"
+  plugin.rpcaudit.logfile: "C:/ProgramData/choria/var/log/mcollective-audit.log"
+  plugin.yaml: "C:/ProgramData/choria/etc/generated-facts.yaml"

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -6,7 +6,7 @@ mcollective::plugin_executable_mode: ~
 mcollective::bindir: "C:/Program Files/Puppet Labs/Puppet/bin"
 mcollective::libdir: "C:/ProgramData/PuppetLabs/mcollective/plugins"
 mcollective::configdir: "C:/ProgramData/PuppetLabs/mcollective/etc"
-mcollective::rubypath: 'C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\ruby.exe'
+mcollective::rubypath: "C:/Program Files/Puppet Labs/Puppet/puppet/bin/ruby.exe"
 mcollective::facts_pidfile: ~
 mcollective::manage_bin_symlinks: false
 


### PR DESCRIPTION
The path was wrong on my Puppet 6 Windows nodes… I guess it changed at some point, and since the module was working with Puppet 5, I made the path selection based on OS and AIO version.