### PR TITLE
(#250) Avoid YAML aliases

### DIFF
--- a/templates/refresh_facts.erb
+++ b/templates/refresh_facts.erb
@@ -61,7 +61,11 @@ Facter.search_external([Puppet[:pluginfactdest]])
 Puppet.initialize_facts
 
 file = Tempfile.new("facter_yaml_writer")
-file.write(Facter.to_hash.to_yaml)
+# The following conversion back-and-forth to JSON is intended to avoid multiple
+# occurence of the same object being output as aliases in the YAML file:
+# aliases are not enabled by default by YAML.safe_load because it can be abused
+# and have security implications.
+file.write(YAML.dump(JSON.load(Facter.to_hash.to_json)))
 file.close
 
 FileUtils.mv(file.path, @outfile)


### PR DESCRIPTION
If Facter build multiple facts from the same object, the serialization
to YAML will generate aliases to avoid duplication.

Aliases can be abused and can be used to cause DOS, so it is advised to
use YANL.safe_load when loading YAML which does not support aliases by
default.  It is done by choria-io/mcorpc-ruby-support.

As a consequence, when a single object is used by more than one fact,
the generated "generated-facts.yaml" file cannot be load.

This commit convert the facts hash to JSON, parse the JSON back to a
new Hash (where all references to the same object will be lost, so
arrays with the same content or different objects) and then converted to
YAML.