### PR TITLE
(#259) add dash to the Mcollective::Collectives pattern

### DIFF
--- a/types/collective.pp
+++ b/types/collective.pp
@@ -1,1 +1,1 @@
-type Mcollective::Collective = Pattern[/\A[a-zA-Z0-9_]+\Z/]
+type Mcollective::Collective = Pattern[/\A[a-zA-Z0-9_-]+\Z/]


### PR DESCRIPTION
hi there.

is there a fundamental reason the "Mcollective::Collective" data type does not include dash "-" in the pattern? given many, most?, cloud providers use "-" in their zone and region names, I think including dash in this pattern would make sense since zones and/or regions are likely common collective names.

thoughts?
+m