### PR TITLE
(#266) Deploy choria on all Puppet 6 / Enable FreeBSD

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -18,8 +18,6 @@ mcollective::server_config:
   plugin.rpcaudit.logfile: "/var/log/puppetlabs/mcollective-audit.log"
   factsource: "yaml"
   plugin.yaml: "/etc/puppetlabs/mcollective/generated-facts.yaml"
-  registerinterval: 10
-  registration: "Choria"
   logfile: "/var/log/puppetlabs/mcollective.log"
   daemonize: 1
 

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -9,6 +9,7 @@ mcollective::gem_provider: "gem"
 mcollective::manage_package: true
 mcollective::required_directories: []
 mcollective::manage_bin_symlinks: false
+mcollective::facts_pidfile: "/var/run/puppet/mcollective-facts_refresh.pid"
 
 mcollective::server_config:
   classesfile: "/var/puppet/state/classes.txt"
@@ -19,7 +20,5 @@ mcollective::server_config:
   plugin.rpcaudit.logfile: "/var/log/mcollective-audit.log"
   factsource: "yaml"
   plugin.yaml: "/usr/local/etc/mcollective/generated-facts.yaml"
-  registerinterval: 10
-  registration: "Choria"
   logfile: "/var/log/mcollective.log"
   daemonize: 1

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -9,8 +9,8 @@ hierarchy:
   - name: "OS family"
     path: "os/%{facts.os.family}.yaml"
 
-  - name: "AIO version specific common"
-    path: "puppet_aio/%{facts.mcollective.aio_major_version}.yaml"
+  - name: "Puppet version specific common"
+    path: "puppet_aio/%{facts.mcollective.puppet_major_version}.yaml"
 
   - name: "common"
     path: "common.yaml"

--- a/metadata.json
+++ b/metadata.json
@@ -105,6 +105,13 @@
       ]
     },
     {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "11",
+        "12"
+      ]
+    },
+    {
       "operatingsystem": "Archlinux"
     }
   ],


### PR DESCRIPTION
This change automatically adds support for Puppet 6 with Choria on
FreeBSD.