### PR TITLE
(#269) mcollective plugins create many http requests due to many file resources

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@
 # @param purge When true will remove unmanaged files from the $configdir/plugin.d, $configdir/policies and $libdir
 # @param gem_source where to find gems, useful for local gem mirrors
 # @param manage_bin_symlinks Enables creating symlinks in the bin dir for the mco command
+# @param file_transfer_type enum to configure global type for file resources in plugins. could be overwritten for every plugin in their defined resource
 class mcollective (
   Array[String[1]] $plugintypes,
   Array[String[1]] $plugin_classes,
@@ -77,6 +78,7 @@ class mcollective (
   Boolean $purge,
   Optional[String[1]] $gem_source = undef,
   String[1] $gem_provider
+  Enum['content', 'source'] $file_transfer_type = 'source',
 ) {
   $factspath = "${configdir}/generated-facts.yaml"
 


### PR DESCRIPTION
as mentioned in the linked issue #269, this PR switches the file
resource in the defined resource mcollective::module_plugin from the
source parameter to content. This heavily reduces the number of http
calls.