### PR TITLE
(#269) mcollective plugins create many http requests due to many file resources

### DIFF
--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -139,11 +139,11 @@ define mcollective::module_plugin (
       }
 
       case $file_transfer_type {
-        'content': {
+        'source': {
           $content = undef
           $source = "puppet:///modules/${caller_module_name}/mcollective/${file}"
         }
-        'source': {
+        'content': {
           $content = file("${caller_module_name}/mcollective/${file}")
           $source = undef
         }


### PR DESCRIPTION
as mentioned in the linked issue #269, this PR switches the file
resource in the defined resource mcollective::module_plugin from the
source parameter to content. This heavily reduces the number of http
calls.