### PR TITLE
( #195) Add an option to disable service management

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -64,9 +64,6 @@ mcollective::client: false
 mcollective::purge: false
 mcollective::facts_refresh_interval: 10
 mcollective::facts_pidfile: "/var/run/puppetlabs/mcollective-facts_refresh.pid"
-mcollective::service_name: "mcollective"
-mcollective::service_ensure: stopped
-mcollective::service_enable: false
 mcollective::plugin_owner: "root"
 mcollective::plugin_group: "root"
 mcollective::plugin_mode: "0644"

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,6 +1,5 @@
 ---
 mcollective::plugin_group: wheel
-mcollective::service_name: mcollectived
 mcollective::configdir: "/usr/local/etc/mcollective"
 mcollective::bindir: "/usr/local/bin"
 mcollective::libdir: "/usr/local/share"

--- a/data/os/OpenBSD.yaml
+++ b/data/os/OpenBSD.yaml
@@ -1,6 +1,5 @@
 ---
 mcollective::plugin_group: wheel
-mcollective::service_name: mcollectived
 mcollective::configdir: "/etc/mcollective"
 mcollective::bindir: "/usr/local/bin"
 mcollective::libdir: "/usr/local/libexec/mcollective"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,12 +48,6 @@ class mcollective::config {
     "daemonize"       => "0"
   }
 
-  if $mcollective::manage_service {
-    $notify_service = Class["mcollective::service"]
-  } else {
-    $notify_service = []
-  }
-
   # The order of these are important:
   #
   # - common config is effectively defaults, overridable by specific server/client settings
@@ -74,8 +68,7 @@ class mcollective::config {
   }
 
   mcollective::config_file{"${mcollective::configdir}/server.cfg":
-    settings => $server_config,
-    notify   => $notify_service
+    ensure => absent,
   }
 
   mcollective::config_file{"${mcollective::configdir}/client.cfg":
@@ -103,7 +96,6 @@ class mcollective::config {
     group   => $mcollective::plugin_group,
     mode    => $mcollective::plugin_mode,
     content => $cu_policy_content,
-    notify  => $notify_service
   }
 
   $ru_policy_content = epp("mcollective/policy_file.epp", {
@@ -118,7 +110,6 @@ class mcollective::config {
     group   => $mcollective::plugin_group,
     mode    => $mcollective::plugin_mode,
     content => $ru_policy_content,
-    notify  => $notify_service
   }
 
   $scout_policy_content = epp("mcollective/policy_file.epp", {
@@ -133,7 +124,6 @@ class mcollective::config {
     group   => $mcollective::plugin_group,
     mode    => $mcollective::plugin_mode,
     content => $scout_policy_content,
-    notify  => $notify_service
   }
 
   if $mcollective::default_rego_policy_source != "" {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,6 +48,12 @@ class mcollective::config {
     "daemonize"       => "0"
   }
 
+  if $mcollective::manage_service {
+    $notify_service = Class["mcollective::service"]
+  } else {
+    $notify_service = []
+  }
+
   # The order of these are important:
   #
   # - common config is effectively defaults, overridable by specific server/client settings
@@ -69,7 +75,7 @@ class mcollective::config {
 
   mcollective::config_file{"${mcollective::configdir}/server.cfg":
     settings => $server_config,
-    notify   => Class["mcollective::service"]
+    notify   => $notify_service
   }
 
   mcollective::config_file{"${mcollective::configdir}/client.cfg":
@@ -97,7 +103,7 @@ class mcollective::config {
     group   => $mcollective::plugin_group,
     mode    => $mcollective::plugin_mode,
     content => $cu_policy_content,
-    notify  => Class["mcollective::service"]
+    notify  => $notify_service
   }
 
   $ru_policy_content = epp("mcollective/policy_file.epp", {
@@ -112,7 +118,7 @@ class mcollective::config {
     group   => $mcollective::plugin_group,
     mode    => $mcollective::plugin_mode,
     content => $ru_policy_content,
-    notify  => Class["mcollective::service"]
+    notify  => $notify_service
   }
 
   $scout_policy_content = epp("mcollective/policy_file.epp", {
@@ -127,7 +133,7 @@ class mcollective::config {
     group   => $mcollective::plugin_group,
     mode    => $mcollective::plugin_mode,
     content => $scout_policy_content,
-    notify  => Class["mcollective::service"]
+    notify  => $notify_service
   }
 
   if $mcollective::default_rego_policy_source != "" {

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -27,7 +27,7 @@ class mcollective::facts (
     exec{"mcollective_facts_yaml_refresh":
       command => "\"${rubypath}\" \"${scriptpath}\" -o \"${factspath}\"",
       creates => $creates,
-      require => Class["mcollective::service"]
+      require => Class["mcollective::config"]
     }
   } else {
     $cron_ensure = "absent"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,10 +29,6 @@
 # @param manage_package Install mcollective package on this node
 # @param package_name The name of the package to install if manage_package is enabled
 # @param package_ensure Ensure value for the package
-# @param manage_service Manage mcollectived service on this node
-# @param service_ensure Ensure value for the service
-# @param service_name The mcollective service name to notify and manage
-# @param service_enable The enable value for the service
 # @param client Install client files on this node
 # @param server Install server files on this node
 # @param purge When true will remove unmanaged files from the $configdir/plugin.d, $configdir/policies and $libdir
@@ -71,10 +67,6 @@ class mcollective (
   Boolean $manage_package,
   Enum["present", "latest"] $package_ensure,
   String[1] $package_name,
-  Boolean $manage_service = true,
-  Enum["stopped", "running"] $service_ensure,
-  String[1] $service_name,
-  Boolean $service_enable,
   Boolean $client,
   Boolean $server,
   Boolean $purge,
@@ -90,9 +82,6 @@ class mcollective (
   contain mcollective::plugin_dirs
   contain mcollective::config
   contain mcollective::facts
-  if $mcollective::manage_service {
-    contain mcollective::service
-  }
 
   contain $plugin_classes - $plugin_classes_exclude
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@
 # @param manage_package Install mcollective package on this node
 # @param package_name The name of the package to install if manage_package is enabled
 # @param package_ensure Ensure value for the package
+# @param manage_service Manage mcollectived service on this node
 # @param service_ensure Ensure value for the service
 # @param service_name The mcollective service name to notify and manage
 # @param service_enable The enable value for the service
@@ -70,6 +71,7 @@ class mcollective (
   Boolean $manage_package,
   Enum["present", "latest"] $package_ensure,
   String[1] $package_name,
+  Boolean $manage_service = true,
   Enum["stopped", "running"] $service_ensure,
   String[1] $service_name,
   Boolean $service_enable,
@@ -88,7 +90,9 @@ class mcollective (
   contain mcollective::plugin_dirs
   contain mcollective::config
   contain mcollective::facts
-  contain mcollective::service
+  if $mcollective::manage_service {
+    contain mcollective::service
+  }
 
   contain $plugin_classes - $plugin_classes_exclude
 }

--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -160,9 +160,5 @@ define mcollective::module_plugin (
 
       Package <| tag == "mcollective_plugin_${name}_packages" |> -> File["${libdir}/mcollective/${file}"]
     }
-
-    if $mcollective::manage_service {
-      Mcollective::Module_plugin[$name] ~> Class["mcollective::service"]
-    }
   }
 }

--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -161,6 +161,8 @@ define mcollective::module_plugin (
       Package <| tag == "mcollective_plugin_${name}_packages" |> -> File["${libdir}/mcollective/${file}"]
     }
 
-    Mcollective::Module_plugin[$name] ~> Class["mcollective::service"]
+    if $mcollective::manage_service {
+      Mcollective::Module_plugin[$name] ~> Class["mcollective::service"]
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,0 @@
-class mcollective::service {
-  service{$mcollective::service_name:
-    ensure => $mcollective::service_ensure,
-    enable => $mcollective::service_enable
-  }
-}


### PR DESCRIPTION
I am not sure to be up-to-date by using this module to deploy the various plugins of `mcollective`…  I wanted to switch to `choria-mcorpc-support` and since with this gem there is no service to manage, it's causing trouble.

Here is a proposal that allows me to disable service management and use a custom package to install the ~~(not-yet-committed)~~ [FreeBSD port for `choria-mcorpc-support`](https://www.freshports.org/sysutils/rubygem-choria-mcorpc-support/).

---

When using the `choria-mcorpc-support` gem instead of `mcollective`, there is no service to ensure running or stopped.  By adding this flag, we allow users to use the new gem:

```puppet
class profile::choria::server (
  Boolean $client = false,
) {
  # [...]

  class { 'mcollective':
    client         => $client,
    package_name   => 'rubygem-choria-mcorpc-support',
    manage_service => false,
    plugin_classes => [
      'mcollective_agent_bolt_tasks',
      'mcollective_agent_filemgr',
      'mcollective_agent_nettest',
      'mcollective_agent_package',
      'mcollective_agent_puppet',
      'mcollective_agent_service',
      'mcollective_choria',
      'mcollective_util_actionpolicy',
    ],
  }
}
```