### PR TITLE
Adjust libdir on FreeBSD

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -2,7 +2,7 @@
 mcollective::plugin_group: wheel
 mcollective::configdir: "/usr/local/etc/choria"
 mcollective::bindir: "/usr/local/bin"
-mcollective::libdir: "/usr/local/share"
+mcollective::libdir: "/usr/local/share/choria/plugins"
 mcollective::rubypath: "/usr/local/bin/ruby"
 mcollective::gem_provider: "gem"
 mcollective::required_directories: []


### PR DESCRIPTION
Files in /usr/local/share are precious, and this libdir is now being cleanned
so better cleanup a more mcollecive-sounding directory!

This change leave some cruft in /usr/local/share/mcollective but I do not think
that adding FreeBSD-specific cleanup code worth it…  Please let me know if you
want the cleanup to be part of the module.