### PR TITLE
(misc) Fix duplicate resource with latest choria-mcollective

### DIFF
--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -12,7 +12,6 @@ mcollective::manage_bin_symlinks: false
 
 mcollective::required_directories:
   - "C:/ProgramData/choria"
-  - "C:/ProgramData/choria/etc"
   - "C:/ProgramData/choria/lib"
   - "C:/ProgramData/choria/var"
   - "C:/ProgramData/choria/var/log"


### PR DESCRIPTION
Fixes this duplicate declaration error:
```
  errors:
    Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: File[C:/ProgramData/choria/etc] is already declared
      file: modules/choria/manifests/config.pp
      line: 29
      factsets: windows-10-64
    cannot redeclare
      file: modules/mcollective/manifests/config.pp
      line: 62
      factsets: windows-10-64
```