### PR TITLE
(misc) Do not use undef mode on windows

### DIFF
--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -1,7 +1,5 @@
 mcollective::plugin_owner: ~
 mcollective::plugin_group: ~
-mcollective::plugin_mode: ~
-mcollective::plugin_executable_mode: ~
 
 mcollective::bindir: "C:/Program Files/choria/bin"
 mcollective::libdir: "C:/ProgramData/choria/lib/plugins"


### PR DESCRIPTION
This is a follow-up to https://github.com/choria-io/go-choria/pull/1066

When setting explicitely files mode to `undef`, users are not able to
access configuration files because windows translate this to `660` /
`770` permissions.

Do not override these values for windows, falling-back to the common
default of `644` / `755` fix the open permission problem:

```
Notice: /Stage[main]/Mcollective::Plugin_dirs/File[C:/ProgramData/choria/lib/plugins]/mode: mode changed '0770' to '0755'
Notice: /Stage[main]/Mcollective::Plugin_dirs/File[C:/ProgramData/choria/lib/plugins/mcollective]/mode: mode changed '0770' to '0755'
Notice: /Stage[main]/Mcollective::Plugin_dirs/File[C:/ProgramData/choria/lib/plugins/mcollective/agent]/mode: mode changed '0770' to '0755'
[...]
Notice: /Stage[main]/Mcollective::Config/Mcollective::Config_file[C:/ProgramData/choria/etc/client.conf]/File[C:/ProgramData/choria/etc/client.conf]/mode: mode changed '0660' to '0644' (corrective)
[...]
Notice: /Stage[main]/Mcollective_agent_puppet/Mcollective::Module_plugin[mcollective_agent_puppet]/Mcollective::Config_file[C:/ProgramData/choria/etc/plugin.d/puppet.cfg]/File[C:/ProgramData/choria/etc/plugin.d/puppet.cfg]/mode: mode changed '0660' to '0644' (corrective)
Notice: /Stage[main]/Mcollective_choria/Mcollective::Module_plugin[mcollective_choria]/Mcollective::Config_file[C:/ProgramData/choria/etc/plugin.d/choria.cfg]/File[C:/ProgramData/choria/etc/plugin.d/choria.cfg]/mode: mode changed '0660' to '0644' (corrective)
Notice: /Stage[main]/Mcollective_util_actionpolicy/Mcollective::Module_plugin[mcollective_util_actionpolicy]/Mcollective::Config_file[C:/ProgramData/choria/etc/plugin.d/actionpolicy.cfg]/File[C:/ProgramData/choria/etc/plugin.d/actionpolicy.cfg]/mode: mode changed '0660' to '0644' (corrective)
Notice: Applied catalog in 5.15 seconds
```