### PR TITLE
(#291) This logfile hardcoded override looks good, but doesn't work for wind…

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,7 +42,6 @@ class mcollective::config {
   # to set to specific values for whatever reason
   $shim_overrides = {
     "rpcaudit"        => "0",
-    "logfile"         => "/var/log/choria-mcorpc.log",
     "collectives"     => "mcollective",
     "main_collective" => "mcollective",
     "daemonize"       => "0"


### PR DESCRIPTION
(#291) Fixed a minor shim config issue causing seemingly-broken mcollective agents on Windows.