### PR TITLE
(#307) Arch Linux: Switch from Ruby 2.7 to 3

### DIFF
--- a/data/os/Archlinux.yaml
+++ b/data/os/Archlinux.yaml
@@ -1,6 +1,6 @@
 ---
 mcollective::libdir: "/etc/puppetlabs/mcollective/plugins"
-mcollective::rubypath: "/usr/bin/ruby-2.7"
+mcollective::rubypath: "/usr/bin/ruby"
 mcollective::required_directories:
   - /etc/puppetlabs/mcollective
 mcollective::manage_bin_symlinks: false


### PR DESCRIPTION
With a recent[0] change Arch Linux switched from Puppet 6 with Ruby 2.7
to Puppet 7 with Ruby 3. Choria needs to use the same Ruby path

[0]: https://github.com/archlinux/svntogit-community@883d829#diff-3e341d2d9c67be01819b25b25d5e53ea3cdf3a38d28846cda85a195eb9b7203a