### PR TITLE
(#318) call Facter.value() within setcode

### DIFF
--- a/lib/facter/mcollective.rb
+++ b/lib/facter/mcollective.rb
@@ -1,8 +1,7 @@
 Facter.add(:mcollective) do
-  pver = Facter.value(:puppetversion)
-  aiover = Facter.value(:aio_agent_version)
-
   setcode do
+    pver = Facter.value(:puppetversion)
+    aiover = Facter.value(:aio_agent_version)
     result = {
       "client" => {},
       "server" => {},


### PR DESCRIPTION
This fixes a rather odd error from #318. I can reproduce this with PE
2021.6.0. It contains Facter 4.2.8 and Puppet 7.16.0. I don't think this
is PE specific, but I don't have a FOSS box with the same versions.
However I remember discussions in the #puppet slack where people said
Facter.value() should be within setcode blocks and not outside.

The referenced facts do exist:

```
{
  "aio_agent_version": "7.16.0",
  "facterversion": "4.2.8",
  "puppetversion": "7.16.0"
}
```