### PR TITLE
Add systemd.timer as a run mode along with cron

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -4,7 +4,7 @@ class mcollective::facts (
   String $configdir = $mcollective::configdir,
   String $factspath = $mcollective::factspath,
   Integer $refresh_interval = $mcollective::facts_refresh_interval,
-  String[1] $runmode = $mcollective::periodic_runmode,
+  Enum["cron", "systemd.timer"] $runmode = $mcollective::periodic_runmode,
   Optional[String] $owner = $mcollective::plugin_owner,
   Optional[String] $group = $mcollective::plugin_group,
   Optional[String] $pidfile = $mcollective::facts_pidfile,

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -60,7 +60,7 @@ class mcollective::facts (
         command => "'${rubypath}' '${scriptpath}' -o '${factspath}' ${factspid} &> /dev/null",
         minute  => $cron_minutes
       }
-      systemd::timer { "mcollective_facts_yaml_refresh.timer":
+      systemd::timer{"mcollective_facts_yaml_refresh.timer":
         active => false,
         enable => false,
       }

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -77,7 +77,7 @@ class mcollective::facts (
         Type=oneshot
         ExecStart=${rubypath} ${scriptpath} -o ${factspath}
         | EOT
-      systemd::timer { "mcollective_facts_yaml_refresh.timer":
+      systemd::timer{"mcollective_facts_yaml_refresh.timer":
         timer_content   => $_timer,
         service_unit    => "mcollective_facts_yaml_refresh.service",
         service_content => $_service,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class mcollective (
   Stdlib::Absolutepath $rubypath,
   Boolean $manage_bin_symlinks = false,
   Integer $facts_refresh_interval,
-  String[1] $periodic_runmode,
+  Enum["cron", "systemd.timer"] $periodic_runmode = "cron",
   Array[Mcollective::Collective] $collectives,
   Array[Mcollective::Collective] $client_collectives = $collectives,
   Optional[Mcollective::Collective] $main_collective = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@
 # @param libdir The directory where plugins will go in
 # @param configdir Root directory to config files
 # @param facts_refresh_interval Minutes between fact refreshes, set to 0 to disable periodic based refreshes
-# @param periodic_runmode Defaults to "cron" and may be set to "systemd.timer"
+# @param periodic_runmode Specify which provider to use for periodic actions
 # @param rubypath Path to the ruby executable
 # @param collectives A list of collectives the node belongs to
 # @param client_collectives A list of collectives the client has access to, defaults to the same as the node

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,8 @@
 # @param bindir Where to create symlinks for our commands
 # @param libdir The directory where plugins will go in
 # @param configdir Root directory to config files
-# @param facts_refresh_interval Minutes between fact refreshes, set to 0 to disable cron based refreshes
+# @param facts_refresh_interval Minutes between fact refreshes, set to 0 to disable periodic based refreshes
+# @param periodic_runmode Defaults to "cron" and may be set to "systemd.timer"
 # @param rubypath Path to the ruby executable
 # @param collectives A list of collectives the node belongs to
 # @param client_collectives A list of collectives the client has access to, defaults to the same as the node
@@ -46,6 +47,7 @@ class mcollective (
   Stdlib::Absolutepath $rubypath,
   Boolean $manage_bin_symlinks = false,
   Integer $facts_refresh_interval,
+  String[1] $periodic_runmode,
   Array[Mcollective::Collective] $collectives,
   Array[Mcollective::Collective] $client_collectives = $collectives,
   Optional[Mcollective::Collective] $main_collective = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/choria-io/puppet-mcollective",
   "issues_url": "https://github.com/choria-io/puppet-mcollective/issues",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.24.0 < 9.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.24.0 < 9.0.0" },
     { "name": "puppet/systemd", "version_requirement": ">= 3.1.0 < 6.0.0" }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,7 @@
   "issues_url": "https://github.com/choria-io/puppet-mcollective/issues",
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.24.0 < 9.0.0" }
+    { "name": "puppet/systemd", "version_requirement": ">= 3.1.0 < 6.0.0" }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Set default for periodic refreshes as a 'cron'
Alternatime 'systemd.timer' value of mcollective::periodic_runmode can be defined in hiera or puppet code.

commit 5fb16013809e4e995e6ef78fb4d8e6a89021dd8c
Author: Sergey Ivanov <seriv@cs.umd.edu>
Date:   Thu May 11 21:01:51 2023 -0400

    add runmode systemd.timer along with cron