### PR TITLE
(#325) Disable rpcauthorization for shim layer

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,10 +41,11 @@ class mcollective::config {
   # These are overrides for the choria shim that we definitely do not want set or have
   # to set to specific values for whatever reason
   $shim_overrides = {
-    "rpcaudit"        => "0",
-    "collectives"     => "mcollective",
-    "main_collective" => "mcollective",
-    "daemonize"       => "0"
+    "rpcaudit"         => "0",
+    "rpcauthorization" => "0",
+    "collectives"      => "mcollective",
+    "main_collective"  => "mcollective",
+    "daemonize"        => "0"
   }
 
   # The order of these are important:


### PR DESCRIPTION
The shim layer has buggy authorization handling when using nested facts, so disable and just rely on the Choria server authorization that handles nested facts without issue Fixes #325