### PR TITLE
(#328) Allow defining facts refresh as systemd timer

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -57,6 +57,7 @@ mcollective::plugin_classes:
 mcollective::server: true
 mcollective::client: false
 mcollective::purge: true
+mcollective::facts_refresh_type: cron
 mcollective::facts_refresh_interval: 10
 mcollective::facts_pidfile: "/var/run/puppetlabs/mcollective-facts_refresh.pid"
 mcollective::plugin_owner: "root"

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -1,6 +1,7 @@
 mcollective::plugin_owner: ~
 mcollective::plugin_group: ~
 
+mcollective::facts_refresh_type: ~
 mcollective::bindir: "C:/Program Files/choria/bin"
 mcollective::libdir: "C:/ProgramData/choria/lib/plugins"
 mcollective::configdir: "C:/ProgramData/choria/etc"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@
 # @param bindir Where to create symlinks for our commands
 # @param libdir The directory where plugins will go in
 # @param configdir Root directory to config files
+# @param facts_refresh_type Kind of fact refresh to run. Choices are cron or systemd (timer). Does not apply to Windows.
 # @param facts_refresh_interval Minutes between fact refreshes, set to 0 to disable cron based refreshes
 # @param rubypath Path to the ruby executable
 # @param collectives A list of collectives the node belongs to
@@ -45,6 +46,7 @@ class mcollective (
   Stdlib::Absolutepath $configdir,
   Stdlib::Absolutepath $rubypath,
   Boolean $manage_bin_symlinks = false,
+  Optional[Enum['cron', 'systemd']] $facts_refresh_type,
   Integer $facts_refresh_interval,
   Array[Mcollective::Collective] $collectives,
   Array[Mcollective::Collective] $client_collectives = $collectives,

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
   "project_page": "https://github.com/choria-io/puppet-mcollective",
   "issues_url": "https://github.com/choria-io/puppet-mcollective/issues",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.24.0 < 10.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.24.0 < 10.0.0" },
+    { "name": "puppet/systemd", "version_requirement": ">= 5.1.0 < 7.0.0" }
   ],
   "operatingsystem_support": [
     {

--- a/templates/refresh_facts.service.epp
+++ b/templates/refresh_facts.service.epp
@@ -1,0 +1,19 @@
+<%- |
+  String $rubypath,
+  String $scriptpath,
+  String $factspath,
+  String $pidfile,
+| -%>
+#
+# Managed by Puppet, DO NOT EDIT
+#
+[Unit]
+Description=Systemd Service for Mcollective fact refresh
+
+[Service]
+Type=oneshot
+ExecStart=<%= $rubypath %> <%= $scriptpath %> -o <%= $factspath %> -p <%= $pidfile %>
+PIDFile=<%= $pidfile %>
+User=root
+Group=root
+SyslogIdentifier=mcollective-facts-refresh

--- a/templates/refresh_facts.timer.epp
+++ b/templates/refresh_facts.timer.epp
@@ -1,0 +1,16 @@
+<%- |
+  String $oncalendar,
+| -%>
+#
+# Managed by Puppet, DO NOT EDIT
+#
+[Unit]
+Description=Systemd Timer for Mcollective fact refresh
+
+[Timer]
+OnCalendar=<%= $oncalendar %>
+Persistent=false
+RandomizedDelaySec=30
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This allows better observability into this process and systemd will not allow more than one instance to run at a time
Fixes #328