### PR TITLE
(misc) Fix usage of legacy File.exists?

### DIFF
--- a/lib/facter/mcollective.rb
+++ b/lib/facter/mcollective.rb
@@ -27,7 +27,7 @@ Facter.add(:mcollective) do
             "/etc/mcollective/%s.cfg",
           ].each do |path|
             configfile = path % config
-            break if File.exists?(configfile)
+            break if File.exist?(configfile)
           end
         end
 


### PR DESCRIPTION
The File.exists? method was removed in Ruby 3.2. File.exist? is to be
used instead.
