### PR TITLE
(#334) Fix catalog when systemd is not available

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -20,7 +20,7 @@ class mcollective::facts (
   }
 
   if $refresh_interval > 0 and $server {
-    if $refresh_type == "systemd" {
+    if $facts["systemd"] == "systemd" and $refresh_type == "systemd" {
       $cron_ensure = "absent"
       $systemd_ensure = "present"
       $systemd_active = true
@@ -74,19 +74,21 @@ class mcollective::facts (
       command => "'${rubypath}' '${scriptpath}' -o '${factspath}' ${factspid} &> /dev/null",
       minute  => $cron_minutes
     }
-    systemd::timer { "mcollective-facts-refresh.timer":
-      ensure          => $systemd_ensure,
-      active          => $systemd_active,
-      enable          => $systemd_enable,
-      timer_content   => epp("mcollective/refresh_facts.timer.epp", {
+    if $facts["systemd"] == "systemd" {
+      systemd::timer { "mcollective-facts-refresh.timer":
+        ensure          => $systemd_ensure,
+        active          => $systemd_active,
+        enable          => $systemd_enable,
+        timer_content   => epp("mcollective/refresh_facts.timer.epp", {
           "oncalendar" => $timer_on_calendar,
-      }),
-      service_content => epp("mcollective/refresh_facts.service.epp", {
+        }),
+        service_content => epp("mcollective/refresh_facts.service.epp", {
           "rubypath"   => $rubypath,
           "scriptpath" => $scriptpath,
           "factspath"  => $factspath,
           "pidfile"    => $pidfile,
-      }),
+        }),
+      }
     }
   }
 }


### PR DESCRIPTION
On systems where systemd is not available (e.g. FreeBSD), creating
systemd resources even to ensure they are absent cause errors.  We
should only manage systemd resources if the system has systemd.

Rely on the `systemd` fact to determine if systemd is available. This
fact is provided by puppet-systemd since version 0.3.0, way older that
5.1.0 currently required.

Fixes #334
